### PR TITLE
Await params in organization page

### DIFF
--- a/app/(main)/organization/[orgId]/page.tsx
+++ b/app/(main)/organization/[orgId]/page.tsx
@@ -9,13 +9,11 @@ import UserIssues from "./_components/user-issues";
 // 	params: { orgId: string };
 // };
 interface OrganizationPageProps {
-  params: {
-    orgId: string;
-  };
+  params: Promise<{ orgId: string }>;
 }
 export default async function OrganizationPage({ params }: OrganizationPageProps) {
-	const {orgId }=   params
-	const { userId } = await auth();
+        const { orgId } = await params;
+        const { userId } = await auth();
 
 	if (!userId) {
 		redirect("/sign-in");


### PR DESCRIPTION
## Summary
- await `params` in organization page so that params are asynchronous

## Testing
- `npm run build` *(fails: Failed to fetch font `Inter`)*

------
https://chatgpt.com/codex/tasks/task_e_689b0c95cb00832b94e25f40fa3b40ea